### PR TITLE
Update samples for pipeline changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ secret. An example Secret has been provided below.
    #known_hosts: <base64 encoded>
 ```
 
-After applying the Secret with `kubectl apply -f ssh-key-secret.yaml`, associate it with the ServiceAccount you created to run the Appsody Tekton builds. For example, this can be done with `kabanero-operator` service account, which is used by the samples by running
+After applying the Secret with `kubectl apply -f ssh-key-secret.yaml`, associate it with the `ServiceAccount` you created to run the Appsody Tekton builds. For example, this can be done with `kabanero-operator` service account, which is used by the samples by running
 ```bash
 $ kubectl edit sa kabanero-operator yaml
 ```

--- a/test_data/sandbox/sample1/triggers/eventTriggers.yaml
+++ b/test_data/sandbox/sample1/triggers/eventTriggers.yaml
@@ -17,7 +17,7 @@ variables:
     value: ' "image-registry.openshift-image-registry.svc:5000" '
   - name: build.namespace
     value: ' kabanero.namespace ' 
-  - name: build.serviceAccount
+  - name: build.serviceAccountName
     value: ' "kabanero-operator" '
   - name: build.timeout
     value: ' "1h0m0s" '

--- a/test_data/sandbox/sample1/triggers/pull/run.yaml
+++ b/test_data/sandbox/sample1/triggers/pull/run.yaml
@@ -10,5 +10,5 @@ spec:
   - name: git-source
     resourceRef:
       name: git-{{.build.nameSuffix}}
-  serviceAccount: {{.build.serviceAccount}}
+  serviceAccountName: {{.build.serviceAccountName}}
   timeout: {{.build.timeout}}

--- a/test_data/sandbox/sample1/triggers/push/run.yaml
+++ b/test_data/sandbox/sample1/triggers/push/run.yaml
@@ -13,5 +13,5 @@ spec:
   - name: docker-image
     resourceRef:
       name: docker-{{.build.nameSuffix}}
-  serviceAccount: {{.build.serviceAccount}}
+  serviceAccountName: {{.build.serviceAccountName}}
   timeout: {{.build.timeout}}

--- a/test_data/sandbox/sample1/triggers/push/run.yaml
+++ b/test_data/sandbox/sample1/triggers/push/run.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{.build.namespace}}
 spec:
   pipelineRef:
-    name: {{.build.collectionID}}-build-push-pipeline
+    name: {{.build.collectionID}}-build-push-pl
   resources:
   - name: git-source
     resourceRef:

--- a/test_data/sandbox/sample1/triggers/tag/run.yaml
+++ b/test_data/sandbox/sample1/triggers/tag/run.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{.build.nameSuffix}}
   namespace: {{.build.namespace}}
 spec:
-  serviceAccount: {{.build.serviceAccount}}
+  serviceAccountName: {{.build.serviceAccountName}}
   timeout: 
   pipelineRef:
     name: {{.build.collectionID}}-build-tag-push-pipeline

--- a/test_data/sandbox/sample1/triggers/tag/run.yaml
+++ b/test_data/sandbox/sample1/triggers/tag/run.yaml
@@ -7,9 +7,9 @@ spec:
   serviceAccountName: {{.build.serviceAccountName}}
   timeout: 
   pipelineRef:
-    name: {{.build.collectionID}}-build-tag-push-pipeline
+    name: {{.build.collectionID}}-image-retag-pl
   resources:
-    - name: docker-image
+    - name: docker-src-image
       resourceRef:
         name: docker-from-{{.build.nameSuffix}}
     - name: docker-dest-image

--- a/test_data/sandbox/sample2/triggers/eventTriggers.yaml
+++ b/test_data/sandbox/sample2/triggers/eventTriggers.yaml
@@ -17,7 +17,7 @@ eventTriggers:
       - build.jobid : ' jobID() '
       - build.nameSuffix: toDomainName( build.ownerLogin + "-" + build.repositoryName + "-" + build.event + "-" + build.jobid)
       - build.defaultRegistry : ' "image-registry.openshift-image-registry.svc:5000" '
-      - build.serviceAccount : ' "kabanero-operator" '
+      - build.serviceAccountName : ' "kabanero-operator" '
 
       #### Push ####
       - if: ' build.event == "push" '

--- a/test_data/sandbox/sample2/triggers/pull/run.yaml
+++ b/test_data/sandbox/sample2/triggers/pull/run.yaml
@@ -10,5 +10,5 @@ spec:
   - name: git-source
     resourceRef:
       name: git-{{.nameSuffix}}
-  serviceAccount: {{.serviceAccount}}
+  serviceAccountName: {{.serviceAccountName}}
   timeout: {{.timeout}}

--- a/test_data/sandbox/sample2/triggers/push/run.yaml
+++ b/test_data/sandbox/sample2/triggers/push/run.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{.namespace}}
 spec:
   pipelineRef:
-    name: {{.collectionID}}-build-push-pipeline
+    name: {{.collectionID}}-build-push-pl
   resources:
   - name: git-source
     resourceRef:

--- a/test_data/sandbox/sample2/triggers/push/run.yaml
+++ b/test_data/sandbox/sample2/triggers/push/run.yaml
@@ -13,5 +13,5 @@ spec:
   - name: docker-image
     resourceRef:
       name: docker-{{.nameSuffix}}
-  serviceAccount: {{.serviceAccount}}
+  serviceAccountName: {{.serviceAccountName}}
   timeout: {{.timeout}}

--- a/test_data/sandbox/sample2/triggers/tag/run.yaml
+++ b/test_data/sandbox/sample2/triggers/tag/run.yaml
@@ -7,9 +7,9 @@ spec:
   serviceAccountName: {{.serviceAccountName}}
   timeout: 
   pipelineRef:
-    name: {{.collectionID}}-build-tag-push-pipeline
+    name: {{.collectionID}}-image-retag-pl
   resources:
-    - name: docker-image
+    - name: docker-src-image
       resourceRef:
         name: docker-from-{{.nameSuffix}}
     - name: docker-dest-image

--- a/test_data/sandbox/sample2/triggers/tag/run.yaml
+++ b/test_data/sandbox/sample2/triggers/tag/run.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{.nameSuffix}}
   namespace: {{.namespace}}
 spec:
-  serviceAccount: {{.serviceAccount}}
+  serviceAccountName: {{.serviceAccountName}}
   timeout: 
   pipelineRef:
     name: {{.collectionID}}-build-tag-push-pipeline

--- a/test_data/sandbox/tekton-trigger-samples/tekton/pull-triggers.yaml
+++ b/test_data/sandbox/tekton-trigger-samples/tekton/pull-triggers.yaml
@@ -43,7 +43,7 @@ spec:
       name: $(params.pipeline)-run-$(uid)
       namespace: $(params.namespace)
     spec:
-      serviceAccount: kabanero-operator
+      serviceAccountName: kabanero-operator
       pipelineRef:
         name: $(params.pipeline)
       resources:

--- a/test_data/sandbox/tekton-trigger-samples/tekton/push-triggers.yaml
+++ b/test_data/sandbox/tekton-trigger-samples/tekton/push-triggers.yaml
@@ -55,7 +55,7 @@ spec:
       name: $(params.pipeline)-run-$(uid)
       namespace: $(params.namespace)
     spec:
-      serviceAccount: kabanero-operator
+      serviceAccountName: kabanero-operator
       pipelineRef:
         name: $(params.pipeline)
       resources:

--- a/test_data/sandbox/tekton-trigger-samples/tekton/tag-triggers.yaml
+++ b/test_data/sandbox/tekton-trigger-samples/tekton/tag-triggers.yaml
@@ -48,7 +48,7 @@ spec:
       name: $(params.pipeline)-run-$(uid)
       namespace: $(params.namespace)
     spec:
-      serviceAccount: kabanero-operator
+      serviceAccountName: kabanero-operator
       pipelineRef:
         name: $(params.pipeline)
       resources:

--- a/test_data/sandbox/tekton-trigger-samples/triggers/eventTriggers.yaml
+++ b/test_data/sandbox/tekton-trigger-samples/triggers/eventTriggers.yaml
@@ -23,9 +23,9 @@ eventTriggers:
       - build.serviceAccountName : ' "kabanero-operator" '
 
       # Pipeline definitions. Is there a better way to do this?
-      - build.pr.pipeline: ' build.collectionID + "-build-pipeline" '
-      - build.push.pipeline: ' build.collectionID + "-build-push-pipeline" '
-      - build.tag.pipeline: ' build.collectionID + "-image-retag-push-pipeline" '
+      - build.pr.pipeline: ' build.collectionID + "-build-pl" '
+      - build.push.pipeline: ' build.collectionID + "-build-push-pl" '
+      - build.tag.pipeline: ' build.collectionID + "-image-retag-push-pl" '
 
       # Append Kabanero information to the event payload
       - message.body.kabanero.collection: ' build.collectionID '

--- a/test_data/sandbox/tekton-trigger-samples/triggers/eventTriggers.yaml
+++ b/test_data/sandbox/tekton-trigger-samples/triggers/eventTriggers.yaml
@@ -20,7 +20,7 @@ eventTriggers:
       - build.jobid : ' jobID() '
       - build.nameSuffix: toDomainName( build.ownerLogin + "-" + build.repositoryName + "-" + build.event + "-" + build.jobid)
       - build.defaultRegistry : ' "image-registry.openshift-image-registry.svc:5000" '
-      - build.serviceAccount : ' "kabanero-operator" '
+      - build.serviceAccountName : ' "kabanero-operator" '
 
       # Pipeline definitions. Is there a better way to do this?
       - build.pr.pipeline: ' build.collectionID + "-build-pipeline" '


### PR DESCRIPTION
This PR updates the samples to use the updated pipeline names and to use `serviceAccountName` instead of `serviceAccount`.